### PR TITLE
feat: refactor the loop for readability

### DIFF
--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -65,57 +65,65 @@ func (o *WorkerOptions) unsealAndConfigureVault(vc *vaultapi.Client, keyStore kv
 		glog.Error("failed create unsealer client:", err)
 	}
 
+	period := time.Second
+
 	for {
+		time.Sleep(period)
+		period = retryPeriod
+
 		glog.Infoln("checking if vault is initialized...")
+
 		initialized, err := unsl.IsInitialized()
 		if err != nil {
 			glog.Error("failed to get initialized status. reason :", err)
+			continue
+		}
 
-		} else {
-			if !initialized {
-				if err = unsl.CheckReadWriteAccess(); err != nil {
-					glog.Errorf("Failed to check read/write access to key store. reason: %v\n", err)
-					continue
-				}
-				if err = unsl.Init(); err != nil {
-					glog.Error("error initializing vault: ", err)
-				} else {
-					glog.Infoln("vault is initialized")
-				}
-			} else {
-				glog.Infoln("vault is already initialized")
+		if !initialized {
+			glog.Infoln("initialize vault")
 
-				glog.Infoln("checking if vault is sealed...")
-				sealed, err := unsl.IsSealed()
-				if err != nil {
-					glog.Error("failed to get unseal status. reason: ", err)
-				} else {
-					if sealed {
-						if err := unsl.Unseal(); err != nil {
-							glog.Error("failed to unseal vault. reason: ", err)
-						} else {
-							glog.Infoln("vault is unsealed")
+			if err = unsl.CheckReadWriteAccess(); err != nil {
+				glog.Errorf("Failed to check read/write access to key store. reason: %v\n", err)
+				continue
+			}
 
-							for {
-								glog.Infoln("configure vault")
-								err := o.configureVault(vc, keyStore, rootTokenID)
-								if err != nil {
-									glog.Error("failed to configure vault. reason: ", err)
-								} else {
-									glog.Infoln("vault is configured")
-									break
-								}
-							}
-
-						}
-					} else {
-						glog.Infoln("vault is unsealed")
-					}
-				}
+			if err = unsl.Init(); err != nil {
+				glog.Error("error initializing vault: ", err)
+				continue
 			}
 		}
 
-		time.Sleep(retryPeriod)
+		glog.Infoln("checking if vault is sealed...")
+
+		sealed, err := unsl.IsSealed()
+		if err != nil {
+			glog.Error("failed to get unseal status. reason: ", err)
+			continue
+		}
+
+		if !sealed {
+			glog.Infoln("vault is unsealed")
+			continue
+		}
+
+		glog.Infoln("unseal vault")
+
+		if err := unsl.Unseal(); err != nil {
+			glog.Error("failed to unseal vault. reason: ", err)
+			continue
+		}
+
+		for {
+			glog.Infoln("configure vault")
+
+			err := o.configureVault(vc, keyStore, rootTokenID)
+			if err == nil {
+				glog.Infoln("vault is configured")
+				break
+			}
+
+			glog.Error("failed to configure vault. reason: ", err)
+		}
 	}
 }
 


### PR DESCRIPTION
This is a refactoring of the complex _unseal and configure_ loop. By moving the sleep at the beginning, it's possible to early exit with `continue` and avoid all the `else` branches.

cf. https://github.com/adfinis-forks/unsealer/pull/1

thanks to @winpat for the review.