### PR TITLE
Use GitHub App token for release tracker comments

### DIFF
--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -20,9 +21,6 @@ jobs:
 
       - name: Generate LGTM App token
         id: lgtm-app-token
-        if: |
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
@@ -31,9 +29,6 @@ jobs:
           repositories: CHANGELOG
 
       - name: Update release tracker
-        if: |
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -18,15 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Prepare git
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "${GITHUB_USER}"
-          git config --global user.email "${GITHUB_USER}@appscode.com"
-          git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-
       - name: Generate GitHub App token
         id: app-token
         if: |

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Generate GitHub App token
-        id: app-token
+      - name: Generate LGTM App token
+        id: lgtm-app-token
         if: |
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
@@ -36,6 +36,6 @@ jobs:
           github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -13,8 +13,6 @@ jobs:
   build:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -25,6 +25,7 @@ jobs:
           private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: CHANGELOG
+          permission-pull-requests: write
 
       - name: Update release tracker
         env:

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -32,12 +32,24 @@ jobs:
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
           sudo mv bin/hub /usr/local/bin
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: |
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: CHANGELOG
+
       - name: Update release tracker
         if: |
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -27,11 +27,6 @@ jobs:
           git config --global user.email "${GITHUB_USER}@appscode.com"
           git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Generate GitHub App token
         id: app-token
         if: |

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -23,13 +23,35 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+
+      - name: Parse docs repository
+        id: docs-repo
+        env:
+          DOCS_REPOSITORY: ${{ secrets.DOCS_REPOSITORY }}
+        run: |
+          # DOCS_REPOSITORY is expected to be of the form: <host>/<owner>/<name>
+          path="${DOCS_REPOSITORY#*/}"
+          echo "owner=${path%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${path##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate LGTM App token
+        id: lgtm-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: ${{ steps.docs-repo.outputs.owner }}
+          repositories: ${{ steps.docs-repo.outputs.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Clone charts repository
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
           DOCS_REPOSITORY: ${{ secrets.DOCS_REPOSITORY }}
         run: |
-          url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${DOCS_REPOSITORY}.git"
+          url="https://x-access-token:${GITHUB_TOKEN}@${DOCS_REPOSITORY}.git"
           cd $RUNNER_WORKSPACE
           git clone $url
           cd $(basename $DOCS_REPOSITORY)
@@ -39,7 +61,7 @@ jobs:
       - name: Update docs
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
           DOCS_REPOSITORY: ${{ secrets.DOCS_REPOSITORY }}
         run: |
           export DOCS_ROOT=$RUNNER_WORKSPACE/$(basename $DOCS_REPOSITORY)

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -23,11 +23,6 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Clone charts repository
         env:
           GITHUB_USER: ${{ github.actor }}

--- a/hack/scripts/update-release-tracker.sh
+++ b/hack/scripts/update-release-tracker.sh
@@ -71,4 +71,4 @@ case $GITHUB_BASE_REF in
         ;;
 esac
 
-hub api "$api_url" -f body="$msg"
+gh api "$api_url" -f body="$msg"


### PR DESCRIPTION
Mirrors kubedb/installer#2284.
- release-tracker.yml: use LGTM GitHub App installation token to post comments on the tracker issue/PR in the CHANGELOG repo.