### PR TITLE
Grant policy-controller the relay/* backend paths (hub-spoke placement)

### DIFF
--- a/pkg/vault/policy/policy.go
+++ b/pkg/vault/policy/policy.go
@@ -60,16 +60,16 @@ path "auth/kubernetes/role/*" {
 	capabilities = ["create", "update", "read", "delete", "list"]
 }
 
-# OpenBao spoke-agent backend (hub-spoke placement). The operator mounts the
-# agent/ backend, initializes the spoke-CA / hub TLS identity, refreshes the
+# OpenBao spoke-relay backend (hub-spoke placement). The operator mounts the
+# relay/ backend, initializes the spoke-CA / hub TLS identity, refreshes the
 # advertised endpoint, and mints/revokes bootstrap tokens through it. The
-# explicit sys/mounts/agent rule adds the sudo capability mounting a backend
+# explicit sys/mounts/relay rule adds the sudo capability mounting a backend
 # requires (and overrides the broader sys/mounts/* rule for this path).
-path "sys/mounts/agent" {
+path "sys/mounts/relay" {
 	capabilities = ["create", "read", "update", "delete", "sudo"]
 }
 
-path "agent/*" {
+path "relay/*" {
 	capabilities = ["create", "read", "update", "delete", "list"]
 }
 `

--- a/pkg/vault/policy/policy.go
+++ b/pkg/vault/policy/policy.go
@@ -59,6 +59,19 @@ path "auth/kubernetes/role" {
 path "auth/kubernetes/role/*" {
 	capabilities = ["create", "update", "read", "delete", "list"]
 }
+
+# OpenBao spoke-agent backend (hub-spoke placement). The operator mounts the
+# agent/ backend, initializes the spoke-CA / hub TLS identity, refreshes the
+# advertised endpoint, and mints/revokes bootstrap tokens through it. The
+# explicit sys/mounts/agent rule adds the sudo capability mounting a backend
+# requires (and overrides the broader sys/mounts/* rule for this path).
+path "sys/mounts/agent" {
+	capabilities = ["create", "read", "update", "delete", "sudo"]
+}
+
+path "agent/*" {
+	capabilities = ["create", "read", "update", "delete", "list"]
+}
 `
 
 // EnsurePolicyAndPolicyBinding will ensure policy and kubernetes role


### PR DESCRIPTION
The hub `VaultServer` operator drives the OpenBao `relay/` backend with its policy-controller identity to deploy `VaultRelay`s to OCM-managed spoke clusters (see [operator#191](https://github.com/kubevault/operator/pull/191), design section 9.1).

This extends the `policyAdmin` document (`pkg/vault/policy/policy.go`) so that identity can manage the relay backend:

```hcl
path "sys/mounts/relay" { capabilities = ["create", "read", "update", "delete", "sudo"] }
path "relay/*"          { capabilities = ["create", "read", "update", "delete", "list"] }
```

- `sys/mounts/relay` carries `sudo` (mounting a backend requires it) and, being more specific, overrides the broader `sys/mounts/*` rule for that path.
- `relay/*` covers the operations the operator's relaybackend client performs: `ca/init`, `ca/info`, `ca/update-endpoint`, and `bootstrap-tokens` create/revoke.

No behavior change for non-placement deployments — these paths are only exercised when a VaultServer sets `spec.relayPlacementRef`.
